### PR TITLE
Avoid copying when capacity is readily available.

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -382,14 +382,19 @@ func NewParser() *Parser {
 // Parse parses a complete JSON document. Callback will be invoked once
 // for each JSON entity found.
 func (p *Parser) Parse(buf []byte, cb Callback) error {
-	// HACK/TODO:  loose about 3% of performance to fix crasher.
-	// PCMPISTRI seems to be crashing by running past the end of
-	// input strings.  Odd that simply ensuring null padding does not address
-	// this.
-	b := make([]byte, len(buf), len(buf)+16)
-	copy(b, buf)
-	buf = b
-
+	if cap(buf) < len(buf)+16 {
+		// HACK/TODO:  loose about 3% of performance to fix crasher.
+		// PCMPISTRI seems to be crashing by running past the end of
+		// input strings.  Odd that simply ensuring null padding does not address
+		// this.
+		b := make([]byte, len(buf), len(buf)+16)
+		copy(b, buf)
+		buf = b
+	} else {
+		// zeroing the padding just in case
+		var zeroes [16]byte
+		copy(buf[len(buf):cap(buf)], zeroes[0:16])
+	}
 	p.buf = buf
 	p.i = 0
 	p.s = sValue


### PR DESCRIPTION
PCMPISTRI scans 16 bytes at a time so goj relies on padding for perf. It turns out that if there is already 16bytes padding, we can use it rather than copy.
So when we detect the spare capacity, we fill it with zeroes instead of copying. If there's not enough spare capacity, fallback to previous behavior.

Additional benefit: when the callback is invoked, we can verify whether the tokens are extracted from the passed in slice (no copy) vs extracted from the internal cooked buffer (for escaped sequences) and do further optimizations accordingly.