### PR TITLE
move to PCMPESTRI, remove need for allocation and fix buffer overrun

### DIFF
--- a/asm_test.go
+++ b/asm_test.go
@@ -1,0 +1,53 @@
+package goj
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const maxTestBufSize = 17317
+
+func TestScanNumbers(t *testing.T) {
+	buf := make([]byte, maxTestBufSize)
+	for i := 0; i < maxTestBufSize; i++ {
+		buf[i] = byte('0' + (i % 10))
+	}
+
+	for i := 0; i < maxTestBufSize; i++ {
+		x := scanNumberChars(buf[i:], 0)
+		assert.Equal(t, maxTestBufSize, i+x)
+	}
+}
+
+func TestScanPastEnd(t *testing.T) {
+	// 32 byte buffer
+	buf := make([]byte, 32)
+	// polulated with alpha data
+	for i := 0; i < len(buf); i++ {
+		buf[i] = byte('a' + (i % 26))
+	}
+
+	// but there's a quote at byte 8
+	buf[8] = '"'
+
+	// given a slice from bytes 2..4,
+	// we shouldn't detect this quote
+	slice := buf[2:4]
+	slicelen := len(slice)
+	x := scanNonSpecialStringChars(slice, 0)
+	assert.Equal(t, slicelen, x)
+}
+
+func TestScanNonSpecialStringChars(t *testing.T) {
+	buf := make([]byte, maxTestBufSize)
+	for i := 0; i < maxTestBufSize; i++ {
+		buf[i] = byte('a' + (i % 26))
+	}
+	assert.Equal(t, maxTestBufSize, scanNonSpecialStringChars(buf, 0))
+
+	for i := 0; i < maxTestBufSize; i++ {
+		x := scanNonSpecialStringChars(buf, i)
+		assert.Equal(t, maxTestBufSize, i+x)
+	}
+}

--- a/parse.go
+++ b/parse.go
@@ -34,12 +34,10 @@ const (
 	ObjectEnd
 )
 
+// ASM optimized scanning routines
 func hasAsm() bool
-func countSlice(s []uint64) int
-func findStrRange(r []byte, s []byte) int
 func scanNumberChars(s []byte, offset int) int
 func scanNonSpecialStringChars(s []byte, offset int) int
-func scanWhitespaceChars(s []byte, offset int) int
 
 func (t Type) String() string {
 	switch t {
@@ -382,14 +380,6 @@ func NewParser() *Parser {
 // Parse parses a complete JSON document. Callback will be invoked once
 // for each JSON entity found.
 func (p *Parser) Parse(buf []byte, cb Callback) error {
-	// HACK/TODO:  loose about 3% of performance to fix crasher.
-	// PCMPISTRI seems to be crashing by running past the end of
-	// input strings.  Odd that simply ensuring null padding does not address
-	// this.
-	b := make([]byte, len(buf), len(buf)+16)
-	copy(b, buf)
-	buf = b
-
 	p.buf = buf
 	p.i = 0
 	p.s = sValue

--- a/parse_asm.s
+++ b/parse_asm.s
@@ -15,11 +15,13 @@ TEXT ·hasAsm(SB),$0-1
 RET
 
 TEXT ·scanNumberChars(SB),4,$0-40
-    // load range (0-9)
+    // load range 0-9
     MOVQ $0x000000FF3a2F01, BX
     MOVQ BX, X0
+    MOVQ $4, AX
+
     // first argument is the byte array we're scanning
-    MOVQ s_base+0(FP), SI
+    MOVQ s+0(FP), SI
     MOVQ offset+24(FP), BX
     ADDQ BX, SI
 
@@ -27,36 +29,33 @@ TEXT ·scanNumberChars(SB),4,$0-40
     // now load the string length into AX, loop control
     // we'll do one loop for every substring of up to 16 bytes,
     // thats (x + 15) >> 4
-	MOVQ s_len+8(FP), AX
-    SUBQ BX, AX
-    // save off number of bytes
-    MOVQ AX, DX
-    ADDQ $15, AX
-    SHRQ $4, AX
+    MOVQ s_len+8(FP), DX
+    SUBQ BX, DX
 
-	// SI holds the memory address of slice + offset
-    // AX holds the number of iterations required to process the entire array
+    // AX holds $6 - len of our range (argument to PCMPESTRI)
     // X0 holds numeric byte ranges that should cause us to halt scanning
+    // DX holds the number of bytes remaining (argument to PCMPESTRI)
+    // SI holds the memory address of slice + offset
+    // BX holds the number of bytes processed
 
-    TESTQ AX,AX
-    JZ scanNumberCharsEnd
     MOVQ $0, BX
+    TESTQ DX,DX
+    JZ scanNumberCharsEnd
 scanNumberCharsLoop:
-    // PCMPISTRI $0x24, 0(SI), X0
-    BYTE $0x66 ;BYTE $0x0F;	BYTE $0x3A;	BYTE $0x63 ; BYTE $0x06 ; BYTE $0x24
+    PCMPESTRI $0x04, 0(SI), X0
     JC scanNumberCharsFound
     ADDQ $16, SI
-    ADDQ $1, BX
-    DECQ AX
-    TESTQ AX,AX
-    JNZ scanNumberCharsLoop
+    ADDQ $16, BX
+    CMPQ DX, $16
+    SUBQ $16, DX
+    JA scanNumberCharsLoop
 
 scanNumberCharsEnd:
-    MOVQ DX, ret+32(FP)
+    ADDQ DX, BX
+    MOVQ BX, ret+32(FP)
     RET
 
 scanNumberCharsFound:
-    SHLQ $4, BX
     ADDQ CX, BX
     MOVQ BX, ret+32(FP)
     RET
@@ -65,6 +64,8 @@ TEXT ·scanNonSpecialStringChars(SB),4,$0-40
     // load range (control, '"', and '\')
     MOVQ $0x5c5c22221f01, BX
     MOVQ BX, X0
+    MOVQ $6, AX
+
     // first argument is the byte array we're scanning
     MOVQ s+0(FP), SI
     MOVQ offset+24(FP), BX
@@ -74,85 +75,33 @@ TEXT ·scanNonSpecialStringChars(SB),4,$0-40
     // now load the string length into AX, loop control
     // we'll do one loop for every substring of up to 16 bytes,
     // thats (x + 15) >> 4
-	MOVQ s_len+8(FP), AX
-    SUBQ BX, AX
-    // save off number of bytes
-    MOVQ AX, DX
-    ADDQ $15, AX
-    SHRQ $4, AX
+    MOVQ s_len+8(FP), DX
+    SUBQ BX, DX
 
-	// SI holds the memory address of slice + offset
-    // AX holds the number of iterations required to process the entire array
+    // AX holds $6 - len of our range (argument to PCMPESTRI)
     // X0 holds numeric byte ranges that should cause us to halt scanning
+    // DX holds the number of bytes remaining (argument to PCMPESTRI)
+    // SI holds the memory address of slice + offset
+    // BX holds the number of bytes processed
 
-    TESTQ AX,AX
-    JZ scanNonSpecialStringCharsEnd
     MOVQ $0, BX
+    TESTQ DX,DX
+    JZ scanNonSpecialStringCharsEnd
 scanNonSpecialStringCharsLoop:
-    // PCMPISTRI $0x24, 0(SI), X0
-    BYTE $0x66 ;BYTE $0x0F;	BYTE $0x3A;	BYTE $0x63 ; BYTE $0x06 ; BYTE $0x24
+    PCMPESTRI $0x04, 0(SI), X0
     JC scanNonSpecialStringCharsFound
     ADDQ $16, SI
-    ADDQ $1, BX
-    DECQ AX
-    TESTQ AX,AX
-    JNZ scanNonSpecialStringCharsLoop
+    ADDQ $16, BX
+    CMPQ DX, $16
+    SUBQ $16, DX
+    JA scanNonSpecialStringCharsLoop
 
 scanNonSpecialStringCharsEnd:
-    MOVQ DX, ret+32(FP)
-    RET
-
-scanNonSpecialStringCharsFound:
-    SHLQ $4, BX
-    ADDQ CX, BX
+    ADDQ DX, BX
     MOVQ BX, ret+32(FP)
     RET
 
-
-// NOTE: as implemented, the overhead of this routine for terse json outwieghs the
-// benefit
-TEXT ·scanWhitespaceChars(SB),4,$0-40
-    // load range (control, '"', and '\')
-    MOVQ $0xff211f0e0801, BX
-    MOVQ BX, X0
-    // first argument is the byte array we're scanning
-    MOVQ s+0(FP), SI
-    MOVQ offset+24(FP), BX
-    ADDQ BX, SI
-
-    // second argument is the offset into the array
-    // now load the string length into AX, loop control
-    // we'll do one loop for every substring of up to 16 bytes,
-    // thats (x + 15) >> 4
-	MOVQ s_len+8(FP), AX
-    SUBQ BX, AX
-    MOVQ AX, DX
-    ADDQ $15, AX
-    SHRQ $4, AX
-
-	// SI holds the memory address of slice + offset
-    // AX holds the number of iterations required to process the entire array
-    // X0 holds numeric byte ranges that should cause us to halt scanning
-
-    TESTQ AX,AX
-    JZ scanWhitespaceCharsEnd
-    MOVQ $0, BX
-scanWhitespaceCharsLoop:
-    // PCMPISTRI $0x24, 0(SI), X0
-    BYTE $0x66 ;BYTE $0x0F;	BYTE $0x3A;	BYTE $0x63 ; BYTE $0x06 ; BYTE $0x24
-    JC scanWhitespaceCharsFound
-    ADDQ $16, SI
-    ADDQ $1, BX
-    DECQ AX
-    TESTQ AX,AX
-    JNZ scanWhitespaceCharsLoop
-
-scanWhitespaceCharsEnd:
-    MOVQ DX, ret+32(FP)
-    RET
-
-scanWhitespaceCharsFound:
-    SHLQ $4, BX
+scanNonSpecialStringCharsFound:
     ADDQ CX, BX
     MOVQ BX, ret+32(FP)
     RET

--- a/parse_asm.s
+++ b/parse_asm.s
@@ -44,11 +44,12 @@ TEXT ·scanNumberChars(SB),4,$0-40
 scanNumberCharsLoop:
     PCMPESTRI $0x04, 0(SI), X0
     JC scanNumberCharsFound
+    CMPQ DX, $16
+    JLE scanNumberCharsEnd
     ADDQ $16, SI
     ADDQ $16, BX
-    CMPQ DX, $16
     SUBQ $16, DX
-    JA scanNumberCharsLoop
+    JMP scanNumberCharsLoop
 
 scanNumberCharsEnd:
     ADDQ DX, BX
@@ -90,11 +91,12 @@ TEXT ·scanNonSpecialStringChars(SB),4,$0-40
 scanNonSpecialStringCharsLoop:
     PCMPESTRI $0x04, 0(SI), X0
     JC scanNonSpecialStringCharsFound
+    CMPQ DX, $16
+    JLE scanNonSpecialStringCharsEnd
     ADDQ $16, SI
     ADDQ $16, BX
-    CMPQ DX, $16
     SUBQ $16, DX
-    JA scanNonSpecialStringCharsLoop
+    JMP scanNonSpecialStringCharsLoop
 
 scanNonSpecialStringCharsEnd:
     ADDQ DX, BX

--- a/parse_asm.s
+++ b/parse_asm.s
@@ -22,17 +22,16 @@ TEXT ·scanNumberChars(SB),4,$0-40
 
     // first argument is the byte array we're scanning
     MOVQ s+0(FP), SI
+    // second argument is the offset into the array
     MOVQ offset+24(FP), BX
     ADDQ BX, SI
 
-    // second argument is the offset into the array
-    // now load the string length into AX, loop control
-    // we'll do one loop for every substring of up to 16 bytes,
-    // thats (x + 15) >> 4
+    // now load the string length into DX, we'll use this
+    // both as an argument to PCMPESTRI and as loop control
     MOVQ s_len+8(FP), DX
     SUBQ BX, DX
 
-    // AX holds $6 - len of our range (argument to PCMPESTRI)
+    // AX holds $4 - byte len of our range (argument to PCMPESTRI)
     // X0 holds numeric byte ranges that should cause us to halt scanning
     // DX holds the number of bytes remaining (argument to PCMPESTRI)
     // SI holds the memory address of slice + offset
@@ -69,13 +68,12 @@ TEXT ·scanNonSpecialStringChars(SB),4,$0-40
 
     // first argument is the byte array we're scanning
     MOVQ s+0(FP), SI
+    // second argument is the offset into the array
     MOVQ offset+24(FP), BX
     ADDQ BX, SI
 
-    // second argument is the offset into the array
-    // now load the string length into AX, loop control
-    // we'll do one loop for every substring of up to 16 bytes,
-    // thats (x + 15) >> 4
+    // now load the string length into DX, we'll use this
+    // both as an argument to PCMPESTRI and as loop control
     MOVQ s_len+8(FP), DX
     SUBQ BX, DX
 


### PR DESCRIPTION
PCMPISTRI requires implict string length (null padding).  buffer over-run was possible, and a half-brained mitigation was in place that was inefficient.  This moves to explicit length SSE scanning (PCMPESTRI) and removes the allocation.  The result is faster and more correct:

before:
```
$ go test -bench=".*" -run="XXX"
goos: linux
goarch: amd64
pkg: github.com/lloyd/goj/test
BenchmarkGojScanning-24        	     200	   7544816 ns/op	 257.19 MB/s
BenchmarkStdJSONScanning-24    	     100	  14643059 ns/op	 132.52 MB/s
```
after
```
$ go test -bench=".*" -run="XXX"
goos: linux
goarch: amd64
pkg: github.com/lloyd/goj/test
BenchmarkGojScanning-24        	     300	   4842530 ns/op	 400.71 MB/s
BenchmarkStdJSONScanning-24    	     100	  14554536 ns/op	 133.32 MB/s
```