### PR TITLE
fix bug when both key & val is cooked

### DIFF
--- a/test/cases/cooked_k_and_v.json
+++ b/test/cases/cooked_k_and_v.json
@@ -1,0 +1,1 @@
+{"I\tlove":"ch\tch"}

--- a/test/cases/cooked_k_and_v.json.gold
+++ b/test/cases/cooked_k_and_v.json.gold
@@ -1,0 +1,4 @@
+map open '{'
+key: 'I	love'
+string: 'ch	ch'
+map close '}'


### PR DESCRIPTION
fixes an issue whereby if both key and value include escapes, we would over-write the key with the value