### PR TITLE
goj to compile on non-amd64 architectures

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -34,11 +34,6 @@ const (
 	ObjectEnd
 )
 
-// ASM optimized scanning routines
-func hasAsm() bool
-func scanNumberChars(s []byte, offset int) int
-func scanNonSpecialStringChars(s []byte, offset int) int
-
 func (t Type) String() string {
 	switch t {
 	case String:

--- a/parse_asm.go
+++ b/parse_asm.go
@@ -1,0 +1,7 @@
+// +build amd64
+
+package goj
+
+func hasAsm() bool
+func scanNumberChars(s []byte, offset int) int
+func scanNonSpecialStringChars(s []byte, offset int) int

--- a/parse_generic.go
+++ b/parse_generic.go
@@ -5,3 +5,29 @@ package goj
 func hasAsm() bool {
 	return false
 }
+
+// non-asm routines that perform direct byte scanning.
+// bytes.IndexFunc is slower and performs needless coallescing of utf8
+// bytes into runes
+
+func scanNonSpecialStringChars(s []byte, offset int) int {
+	x := 0
+	for x = 0; x < len(s)-offset; x++ {
+		r := rune(s[offset+x])
+		if r == '"' || r == '\\' || r < 0x20 {
+			return x
+		}
+	}
+	return x
+}
+
+func scanNumberChars(s []byte, offset int) int {
+	x := 0
+	for x = 0; x < len(s)-offset; x++ {
+		r := rune(s[offset+x])
+		if r < '0' || r > '9' {
+			return x
+		}
+	}
+	return x
+}

--- a/parse_generic.go
+++ b/parse_generic.go
@@ -12,22 +12,20 @@ func hasAsm() bool {
 
 func scanNonSpecialStringChars(s []byte, offset int) int {
 	x := 0
-	for x = 0; x < len(s)-offset; x++ {
-		r := rune(s[offset+x])
-		if r == '"' || r == '\\' || r < 0x20 {
-			return x
+	for x = offset; x < len(s); x++ {
+		if s[x] == '"' || s[x] == '\\' || s[x] < 0x20 {
+			return x - offset
 		}
 	}
-	return x
+	return x - offset
 }
 
 func scanNumberChars(s []byte, offset int) int {
 	x := 0
-	for x = 0; x < len(s)-offset; x++ {
-		r := rune(s[offset+x])
-		if r < '0' || r > '9' {
-			return x
+	for x = offset; x < len(s); x++ {
+		if s[x] < '0' || s[x] > '9' {
+			return x - offset
 		}
 	}
-	return x
+	return x - offset
 }


### PR DESCRIPTION
A native golang implementation of scanning that allows goj to compile on !amd64 architectures.  As a bonus, we can now benchmark ASM vs non ASM implementations:

```
asm:  BenchmarkGojScanning-24        	     300	   4824463 ns/op	 402.22 MB/s
!asm: BenchmarkGojScanning-24        	     300	   5728835 ns/op	 338.72 MB/s
```

this is on a 
```
Intel(R) Xeon(R) CPU E5-2643 v4 @ 3.40GHz
```


