### PR TITLE
Padding fix

### DIFF
--- a/non_asm_test.go
+++ b/non_asm_test.go
@@ -6,21 +6,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const maxTestBufSize = 17317
-
-func TestScanNumbers(t *testing.T) {
+func TestScanNumbersGo(t *testing.T) {
 	buf := make([]byte, maxTestBufSize)
 	for i := 0; i < maxTestBufSize; i++ {
 		buf[i] = byte('0' + (i % 10))
 	}
 
 	for i := 0; i < maxTestBufSize; i++ {
-		x := scanNumberCharsASM(buf[i:], 0)
+		x := scanNumberCharsGo(buf[i:], 0)
 		assert.Equal(t, maxTestBufSize, i+x)
 	}
 }
 
-func TestScanPastEnd(t *testing.T) {
+func TestScanPastEndGo(t *testing.T) {
 	// 32 byte buffer
 	buf := make([]byte, 32)
 	// polulated with alpha data
@@ -35,19 +33,19 @@ func TestScanPastEnd(t *testing.T) {
 	// we shouldn't detect this quote
 	slice := buf[2:4]
 	slicelen := len(slice)
-	x := scanNonSpecialStringCharsASM(slice, 0)
+	x := scanNonSpecialStringCharsGo(slice, 0)
 	assert.Equal(t, slicelen, x)
 }
 
-func TestScanNonSpecialStringChars(t *testing.T) {
+func TestScanNonSpecialStringCharsGo(t *testing.T) {
 	buf := make([]byte, maxTestBufSize)
 	for i := 0; i < maxTestBufSize; i++ {
 		buf[i] = byte('a' + (i % 26))
 	}
-	assert.Equal(t, maxTestBufSize, scanNonSpecialStringCharsASM(buf, 0))
+	assert.Equal(t, maxTestBufSize, scanNonSpecialStringCharsGo(buf, 0))
 
 	for i := 0; i < maxTestBufSize; i++ {
-		x := scanNonSpecialStringCharsASM(buf, i)
+		x := scanNonSpecialStringCharsGo(buf, i)
 		assert.Equal(t, maxTestBufSize, i+x)
 	}
 }

--- a/parse_asm.s
+++ b/parse_asm.s
@@ -14,7 +14,7 @@ TEXT ·hasAsm(SB),$0-1
     MOVB CX, ret+0(FP)
 RET
 
-TEXT ·scanNumberChars(SB),4,$0-40
+TEXT ·scanNumberCharsASM(SB),4,$0-40
     // load range 0-9
     MOVQ $0x000000FF3a2F01, BX
     MOVQ BX, X0
@@ -60,7 +60,7 @@ scanNumberCharsFound:
     MOVQ BX, ret+32(FP)
     RET
 
-TEXT ·scanNonSpecialStringChars(SB),4,$0-40
+TEXT ·scanNonSpecialStringCharsASM(SB),4,$0-40
     // load range (control, '"', and '\')
     MOVQ $0x5c5c22221f01, BX
     MOVQ BX, X0


### PR DESCRIPTION
If the end of a JSON record is within sixteen bytes of a page boundary then a potential seg fault can occur. This is because when scanning strings or numbers using the assembly functions 16 bytes are read regardless of byte length.

As a solution, switch to go version of scanning if the end of a record is near a page boundary.