### PR TITLE
cleaned support for amd64 and non-amd64 platforms

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/lloyd/goj
+
+go 1.20
+
+require github.com/stretchr/testify v1.8.4
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/parse.go
+++ b/parse.go
@@ -53,11 +53,6 @@ const (
 	Skip
 )
 
-// ASM optimized scanning routines
-func hasAsm() bool
-func scanNumberCharsASM(s []byte, offset int) int
-func scanNonSpecialStringCharsASM(s []byte, offset int) int
-
 //go:nosplit
 func scanNonSpecialStringCharsGo(s []byte, offset int) (x int) {
 	for i, c := range s[offset:] {
@@ -78,8 +73,6 @@ func scanNumberCharsGo(s []byte, offset int) (x int) {
 	return len(s) - offset
 }
 
-func scanBraces(s []byte, offset int) int
-func scanBrackets(s []byte, offset int) int
 
 //go:nosplit
 func scanBracesGo(s []byte, offset int) int {

--- a/parse_amd64.go
+++ b/parse_amd64.go
@@ -1,0 +1,11 @@
+//go:build amd64
+// +build amd64
+
+package goj
+
+// ASM optimized scanning routines stubs
+func hasAsm() bool
+func scanNumberCharsASM(s []byte, offset int) int
+func scanNonSpecialStringCharsASM(s []byte, offset int) int
+func scanBraces(s []byte, offset int) int
+func scanBrackets(s []byte, offset int) int

--- a/parse_generic.go
+++ b/parse_generic.go
@@ -1,7 +1,21 @@
+//go:build !amd64
 // +build !amd64
 
 package goj
 
 func hasAsm() bool {
 	return false
+}
+func scanNumberCharsASM(s []byte, offset int) int {
+	return scanNumberCharsGo(s, offset)
+}
+func scanNonSpecialStringCharsASM(s []byte, offset int) int {
+	return scanNonSpecialStringCharsGo(s, offset)
+}
+
+func scanBraces(s []byte, offset int) int {
+	return scanBracesGo(s, offset)
+}
+func scanBrackets(s []byte, offset int) int {
+	return scanBracketsGo(s, offset)
 }


### PR DESCRIPTION
non-amd64 builds of the packages were failing due to missing function implementations, cleaned up the code.